### PR TITLE
Add handling of pagination of jobs results.

### DIFF
--- a/brickops/databricks/api.py
+++ b/brickops/databricks/api.py
@@ -73,7 +73,14 @@ class ApiClient:
         return result["jobs"][0]  # type: ignore [no-any-return]
 
     def get_jobs(self: ApiClient) -> list[dict[str, Any]]:
-        return self.get("jobs/list").get("jobs", [])  # type: ignore [no-any-return]
+        result = self.get("jobs/list", version="2.2")
+        job_list: list[dict[str, Any]] = result.get("jobs", [])
+        while next_page_token := result.get("next_page_token"):
+            result = self.get(
+                "jobs/list", version="2.2", params={"page_token": next_page_token}
+            )
+            job_list.extend(result.get("jobs", []))
+        return job_list
 
     def delete_job(self: ApiClient, job_id: str) -> dict[str, Any]:
         return self.post("jobs/delete", payload={"job_id": job_id})

--- a/tests/databricks/test_api.py
+++ b/tests/databricks/test_api.py
@@ -8,20 +8,33 @@ from brickops.databricks.api import ApiClient, ApiClientError
 
 def test_get_jobs_with_no_results(requests_mock: Any) -> None:  # noqa: ANN401
     client = ApiClient("https://test.com", "test_token")
-    requests_mock.get("https://test.com/api/2.1/jobs/list", json={"jobs": []})
+    requests_mock.get("https://test.com/api/2.2/jobs/list", json={"jobs": []})
     assert client.get_jobs() == []
 
 
 def test_get_jobs_with_result(requests_mock: Any) -> None:  # noqa: ANN401
     client = ApiClient("https://test.com", "test_token")
-    requests_mock.get("https://test.com/api/2.1/jobs/list", json={"jobs": [{"id": 1}]})
+    requests_mock.get("https://test.com/api/2.2/jobs/list", json={"jobs": [{"id": 1}]})
     assert client.get_jobs() == [{"id": 1}]
+
+
+def test_get_jobs_with_paginated_result(requests_mock: Any) -> None:  # noqa: ANN401
+    client = ApiClient("https://test.com", "test_token")
+    requests_mock.get(
+        "https://test.com/api/2.2/jobs/list",
+        json={"jobs": [{"id": 1}], "next_page_token": "token"},
+    )
+    requests_mock.get(
+        "https://test.com/api/2.2/jobs/list?page_token=token",
+        json={"jobs": [{"id": 2}], "next_page_token": None},
+    )
+    assert client.get_jobs() == [{"id": 1}, {"id": 2}]
 
 
 def test_get_jobs_with_requests_exception(requests_mock: Any) -> None:  # noqa: ANN401
     client = ApiClient("https://test.com", "test_token")
     requests_mock.get(
-        "https://test.com/api/2.1/jobs/list", exc=requests.exceptions.RequestException
+        "https://test.com/api/2.2/jobs/list", exc=requests.exceptions.RequestException
     )
     with pytest.raises(ApiClientError) as exc:
         client.get_jobs()


### PR DESCRIPTION
- Jobs results might be paginated, which is now handled. 
- Moved to version 2.2 of API for jobs. 
- Added simple test for paginated results. 