### PR TITLE
get repos from /Shared with ApiClient.get_repos

### DIFF
--- a/brickops/databricks/api.py
+++ b/brickops/databricks/api.py
@@ -248,7 +248,14 @@ class ApiClient:
         folders_response = self.get(
             "repos", version="2.0", params={"path_prefix": "/Users"}
         )
-        return repos_response.get("repos", []) + folders_response.get("repos", [])  # type: ignore [no-any-return]
+        shared_response = self.get(
+            "repos", version="2.0", params={"path_prefix": "/Shared"}
+        )
+        return (
+            repos_response.get("repos", [])
+            + folders_response.get("repos", [])
+            + shared_response.get("repos", [])
+        )  # type: ignore[no-any-return]
 
     def unpack_response(self: ApiClient, response: requests.Response) -> dict[str, Any]:
         response.raise_for_status()


### PR DESCRIPTION
When I clone a repo in shared/ and then run autodeploy, it won't run because it can't find the git branch. The reason is that `brickops.databricks.api.ApiClient.get_repos` does not retrieve repos from `shared/`, only from `repos/` and `users/`. This PR changes the method so that it also retrieves repos from `shared/`