### PR TITLE
Allow custom run_as

### DIFF
--- a/brickops/dataops/deploy/job/buildconfig/build.py
+++ b/brickops/dataops/deploy/job/buildconfig/build.py
@@ -35,12 +35,13 @@ def build_job_config(
     full_cfg.tags = tags
     full_cfg.parameters.extend(build_context_parameters(env, tags))
     full_cfg = enrich_tasks(job_config=full_cfg, db_context=db_context)
-    if db_context.is_service_principal:
-        full_cfg.run_as = {"service_principal_name": db_context.username}
-    else:  # if we have a service principal, we need to use the correct config
-        full_cfg.run_as = {
-            "user_name": db_context.username,
-        }
+    if not full_cfg.run_as:
+        if db_context.is_service_principal:
+            full_cfg.run_as = {"service_principal_name": db_context.username}
+        else:  # if we have a service principal, we need to use the correct config
+            full_cfg.run_as = {
+                "user_name": db_context.username,
+            }
 
     return full_cfg
 

--- a/tests/dataops/deploy/job/buildconfig/test_build_job_config.py
+++ b/tests/dataops/deploy/job/buildconfig/test_build_job_config.py
@@ -27,6 +27,23 @@ def basic_config() -> dict[str, Any]:
         },
     }
 
+@pytest.fixture
+def config_w_run_as() -> dict[str, Any]:
+    return {
+        "run_as": {"service_principal_name": "mysp"},
+        "tasks": [
+            {
+                "task_key": "task_key",
+                "job_cluster_key": "common-job-cluster",
+            }
+        ],
+        "git_source": {
+            "git_url": "git_url",
+            "git_branch": "git_branch",
+            "git_commit": "abcdefgh123",
+            "git_path": "/Repos/test@vlfk.no/dp-notebooks/",
+        },
+    }
 
 @pytest.fixture
 def db_context() -> DbContext:
@@ -74,6 +91,12 @@ def test_that_build_job_sets_correct_run_as(
     result = build_job_config(basic_config, "test", db_context)
     assert result.run_as == {"user_name": "TestUser@vlfk.no"}
 
+def test_that_build_job_handles_specified_run_as(
+        config_w_run_as: dict[str, Any],
+        db_context: DbContext
+    ) -> None:
+    result = build_job_config(config_w_run_as, "test", db_context)
+    assert result.run_as == {"service_principal_name": "mysp"}
 
 def test_that_tags_are_set_correctly(
     basic_config: dict[str, Any], db_context: DbContext


### PR DESCRIPTION
If you specify a custom `run_as` in the config to `autojob`, this configuration will be overridden by `brickops.dataops.deploy.job.buildconfig.build.build_job_config`, setting the current user as `run_as`.  In this PR, I add a check to see if run_as is set before setting the current user to run_as. I also added a test for this